### PR TITLE
Add drag-and-drop stop group page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /node_modules
 src/vite-env.d.ts
 .env.development
-.env.development
+dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,11 @@
       "name": "dashboard-v2",
       "version": "0.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/modifiers": "^9.0.0",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
+        "@radix-ui/react-accordion": "^1.2.11",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
         "@radix-ui/react-scroll-area": "^1.2.9",
@@ -335,6 +340,73 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/modifiers": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
+      "integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1118,6 +1190,37 @@
       "integrity": "sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==",
       "license": "MIT"
     },
+    "node_modules/@radix-ui/react-accordion": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.11.tgz",
+      "integrity": "sha512-l3W5D54emV2ues7jjeG1xcyN7S3jnK3zE2zHqgn0CmMsy9lNJwmgcrmaxS+7ipw15FAivzKNzH3d5EcGoFKw0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-collapsible": "1.1.11",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
@@ -1125,6 +1228,36 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.11.tgz",
+      "integrity": "sha512-2qrRsVGSCYasSz1RFOorXwl0H7g7J1frQtgpQgYrt+MOidtPAINHn9CPovQXb83r8ahapdx3Tu0fa/pdFFSdPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
+    "@radix-ui/react-accordion": "^1.2.11",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-scroll-area": "^1.2.9",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import {BrowserRouter, Route, Routes} from 'react-router-dom'
 import Layout from "@/components/ui/layout.tsx";
 import Students from "@/components/pages/students.tsx";
+import StopGroups from "@/components/pages/stopgroups.tsx";
 
 
 function App() {
@@ -11,6 +12,7 @@ function App() {
                 <Routes>
                     <Route path="/" element={<Students />} />
                     <Route path="/students" element={<Students />} />
+                    <Route path="/stop-groups" element={<StopGroups />} />
                 </Routes>
             </Layout>
         </BrowserRouter>

--- a/src/components/pages/stopgroups.tsx
+++ b/src/components/pages/stopgroups.tsx
@@ -1,0 +1,208 @@
+import {useState} from 'react';
+import {DndContext, closestCenter, PointerSensor, useSensor, useSensors} from '@dnd-kit/core';
+import type {DragEndEvent} from '@dnd-kit/core';
+import {
+    arrayMove,
+    SortableContext,
+    useSortable,
+    verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import {CSS} from '@dnd-kit/utilities';
+import {Accordion, AccordionContent, AccordionItem, AccordionTrigger} from '@radix-ui/react-accordion';
+import {Button} from '@/components/ui/button';
+import {Card, CardContent, CardDescription, CardHeader, CardTitle} from '@/components/ui/card';
+import {Input} from '@/components/ui/input';
+import {Separator} from '@/components/ui/separator';
+
+interface Stop {
+    id: number;
+    name: string;
+}
+
+interface StopGroup {
+    id: number;
+    name: string;
+    description: string;
+    stopIds: number[];
+    collapsed?: boolean;
+}
+
+const initialStops: Stop[] = [
+    {id: 1, name: 'Stop 1'},
+    {id: 2, name: 'Stop 2'},
+    {id: 3, name: 'Stop 3'},
+    {id: 4, name: 'Stop 4'},
+];
+
+const initialGroups: StopGroup[] = [
+    {id: 1, name: 'Group A', description: 'First group', stopIds: [1]},
+    {id: 2, name: 'Group B', description: 'Second group', stopIds: [2]},
+    {id: 3, name: 'Group C', description: 'Third group', stopIds: []},
+];
+
+function SortableItem({id, data, children}: {id: string; data?: Record<string, unknown>; children: React.ReactNode}) {
+    const {attributes, listeners, setNodeRef, transform, transition} = useSortable({id, data});
+    const style = {
+        transform: CSS.Transform.toString(transform),
+        transition,
+    };
+    return (
+        <div ref={setNodeRef} style={style} {...attributes} {...listeners} className="border rounded-md p-2 bg-background shadow-sm flex justify-between items-center">
+            {children}
+        </div>
+    );
+}
+
+export default function StopGroups() {
+    const [groups, setGroups] = useState<StopGroup[]>(initialGroups);
+    const [unassigned, setUnassigned] = useState<Stop[]>(initialStops.filter(s => !initialGroups.some(g => g.stopIds.includes(s.id))));
+    const [filter, setFilter] = useState('');
+
+    const sensors = useSensors(
+        useSensor(PointerSensor, {
+            activationConstraint: {
+                distance: 5,
+            },
+        })
+    );
+
+    const handleDragEnd = (event: DragEndEvent) => {
+        const {active, over} = event;
+        if (!over) return;
+
+        const activeData = active.data.current as {type: string; groupId?: number; stopId?: number};
+        const overData = over.data.current as {type: string; groupId?: number; stopId?: number};
+
+        if (activeData?.type === 'group' && overData?.type === 'group') {
+            if (active.id !== over.id) {
+                const oldIndex = groups.findIndex(g => `group-${g.id}` === active.id);
+                const newIndex = groups.findIndex(g => `group-${g.id}` === over.id);
+                setGroups(g => arrayMove(g, oldIndex, newIndex));
+            }
+        }
+
+        if (activeData?.type === 'stop') {
+            const fromGroupId = activeData.groupId;
+            if (overData.type === 'unassigned') {
+                if (fromGroupId) {
+                    setGroups(gs => gs.map(g => g.id === fromGroupId ? {...g, stopIds: g.stopIds.filter(id => id !== activeData.stopId)} : g));
+                }
+                const movedStop = (fromGroupId ? groups.find(g => g.id === fromGroupId)?.stopIds.includes(activeData.stopId!) : true)
+                    ? {id: activeData.stopId!, name: active.id.toString()}
+                    : unassigned.find(s => s.id === activeData.stopId!);
+                if (movedStop && !unassigned.some(s => s.id === movedStop.id)) {
+                    setUnassigned(u => [...u, movedStop]);
+                }
+            } else if (overData.type === 'group') {
+                const targetGroupId = overData.groupId!;
+                if (fromGroupId === targetGroupId) return;
+                setGroups(gs => gs.map(g => {
+                    if (g.id === fromGroupId) {
+                        return {...g, stopIds: g.stopIds.filter(id => id !== activeData.stopId)};
+                    }
+                    if (g.id === targetGroupId) {
+                        return {...g, stopIds: [...g.stopIds, activeData.stopId!]};
+                    }
+                    return g;
+                }));
+                if (!fromGroupId) {
+                    setUnassigned(u => u.filter(s => s.id !== activeData.stopId));
+                }
+            }
+        }
+    };
+
+    const addGroup = () => {
+        const id = Math.max(0, ...groups.map(g => g.id)) + 1;
+        setGroups([...groups, {id, name: `Group ${id}`, description: 'New group', stopIds: []}]);
+    };
+
+    const addStop = () => {
+        const id = Math.max(0, ...unassigned.map(s => s.id), ...groups.flatMap(g => g.stopIds)) + 1;
+        setUnassigned([...unassigned, {id, name: `Stop ${id}`}]);
+    };
+
+    const collapseAll = () => {
+        setGroups(gs => gs.map(g => ({...g, collapsed: true})));
+    };
+
+    return (
+        <div className="container mx-auto py-4 space-y-4">
+            <div className="flex justify-between items-center">
+                <h1 className="text-2xl font-bold">Manage Stop Groups</h1>
+                <div className="flex gap-2">
+                    <Button onClick={addGroup}>Add StopGroup</Button>
+                    <Button onClick={addStop} variant="secondary">Add Stop</Button>
+                </div>
+            </div>
+            <Separator />
+            <div className="flex flex-col md:flex-row gap-4">
+                <div className="flex-1 space-y-2">
+                    <div className="flex justify-between items-center">
+                        <h2 className="text-xl font-semibold">Stop Groups</h2>
+                        <Button variant="ghost" onClick={collapseAll}>Collapse All</Button>
+                    </div>
+                    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+                        <SortableContext items={groups.map(g => `group-${g.id}`)} strategy={verticalListSortingStrategy}>
+                            {groups.map(group => (
+                                <SortableItem key={`group-${group.id}`} id={`group-${group.id}`} data={{type:'group',groupId:group.id}}>
+                                    <div className="w-full">
+                                        <Accordion type="single" collapsible value={group.collapsed ? undefined : String(group.id)} onValueChange={val => setGroups(gs => gs.map(g => g.id === group.id ? {...g, collapsed: !val} : g))}>
+                                            <AccordionItem value={String(group.id)}>
+                                                <AccordionTrigger className="flex justify-between w-full py-2">{group.name}</AccordionTrigger>
+                                                <AccordionContent className="pb-4">
+                                                    <Card className="bg-secondary/20">
+                                                        <CardHeader className="pb-2">
+                                                            <CardTitle>{group.name}</CardTitle>
+                                                            <CardDescription>{group.description}</CardDescription>
+                                                        </CardHeader>
+                                                        <CardContent className="space-y-2">
+                                                            <SortableContext items={group.stopIds.map(id => `stop-${id}`)} strategy={verticalListSortingStrategy}>
+                                                                {group.stopIds.map(id => {
+                                                                    const stop = [...unassigned, ...initialStops].find(s => s.id === id) || {id, name: `Stop ${id}`};
+                                                                    return (
+                                                                        <SortableItem key={`stop-${stop.id}`} id={`stop-${stop.id}`}
+              data={{type:'stop',stopId:stop.id,groupId:group.id}}>
+                                                                            <span>{stop.name}</span>
+                                                                            <Button size="sm" variant="ghost" onClick={() => {
+                                                                                setGroups(gs => gs.map(g => g.id === group.id ? {...g, stopIds: g.stopIds.filter(sid => sid !== stop.id)} : g));
+                                                                                setUnassigned(u => [...u, stop]);
+                                                                            }}>Remove</Button>
+                                                                        </SortableItem>
+                                                                    );
+                                                                })}
+                                                            </SortableContext>
+                                                        </CardContent>
+                                                    </Card>
+                                                </AccordionContent>
+                                            </AccordionItem>
+                                        </Accordion>
+                                    </div>
+                                </SortableItem>
+                            ))}
+                        </SortableContext>
+                        <div data-id="unassigned" data-type="unassigned" className="hidden" />
+                    </DndContext>
+                </div>
+                <div className="md:w-64 space-y-2">
+                    <h2 className="text-xl font-semibold">Unassigned Stops</h2>
+                    <Input placeholder="Filter" value={filter} onChange={e => setFilter(e.target.value)} />
+                    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+                        <SortableContext items={unassigned.filter(s => s.name.toLowerCase().includes(filter.toLowerCase())).map(s => `stop-${s.id}`)} strategy={verticalListSortingStrategy}>
+                            {unassigned.filter(s => s.name.toLowerCase().includes(filter.toLowerCase())).map(stop => (
+                                <SortableItem key={`stop-${stop.id}`} id={`stop-${stop.id}`} data={{type:'stop',stopId:stop.id}}>
+                                    <span>{stop.name}</span>
+                                </SortableItem>
+                            ))}
+                        </SortableContext>
+                    </DndContext>
+                </div>
+            </div>
+            <div className="flex justify-end gap-2">
+                <Button variant="secondary" onClick={() => window.location.reload()}>Cancel</Button>
+                <Button onClick={() => console.log(groups, unassigned)}>Save Changes</Button>
+            </div>
+        </div>
+    );
+}
+

--- a/src/components/ui/app-sidebar.tsx
+++ b/src/components/ui/app-sidebar.tsx
@@ -20,6 +20,11 @@ const items = [
         icon: UsersRoundIcon,
     },
     {
+        title: "Stop Groups",
+        url: "/stop-groups",
+        icon: Calendar,
+    },
+    {
         title: "Inbox",
         url: "#",
         icon: Inbox,


### PR DESCRIPTION
## Summary
- install DnD kit and Radix Accordion
- add new `StopGroups` page with sortable drag-and-drop interface
- register the new page in the router and sidebar
- ignore build output in git

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685298f27a888328bade8192645d8ee5