### PR TITLE
Add StopGroups drag-and-drop page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import {BrowserRouter, Route, Routes} from 'react-router-dom'
 import Layout from "@/components/ui/layout.tsx";
 import Students from "@/components/pages/students.tsx";
 import DashboardHome from "@/components/pages/Home.tsx";
+import StopGroupsPage from "@/components/pages/stopgroups.tsx";
 
 
 function App() {
@@ -12,7 +13,7 @@ function App() {
                 <Routes>
                     <Route path="/" element={<DashboardHome />}></Route>
                     <Route path="/students" element={<Students />} />
-                    <Route path="/stopgroups" element={<div>Stop Groups Page</div>} />
+                    <Route path="/stopgroups" element={<StopGroupsPage />} />
                 </Routes>
             </Layout>
         </BrowserRouter>

--- a/src/components/pages/stopgroups.tsx
+++ b/src/components/pages/stopgroups.tsx
@@ -1,0 +1,229 @@
+"use client"
+
+import {
+    DndContext,
+    DragOverlay,
+    PointerSensor,
+    useSensor,
+    useSensors,
+    KeyboardSensor,
+    closestCenter,
+} from "@dnd-kit/core"
+import type { DragEndEvent, DragStartEvent } from "@dnd-kit/core"
+import { sortableKeyboardCoordinates, SortableContext, verticalListSortingStrategy, arrayMove } from "@dnd-kit/sortable"
+import { useEffect, useState } from "react"
+import { StopGroupHeader } from "@/components/ui/stopgroups-header"
+import { CollapsibleSection } from "@/components/ui/collapsible-section"
+import { UnassignedStops } from "@/components/ui/unassigned-stops"
+import { DragItem } from "@/components/ui/drag-item"
+import type { Stop, StopGroup } from "@/types/types.ts"
+import { useIsMobile } from "@/hooks/use-mobile.ts"
+
+type StopInstance = Stop & { uid: string }
+type StopGroupWithStops = StopGroup & { stops: StopInstance[]; isExpanded: boolean }
+
+export default function StopGroupsPage() {
+    const isMobile = useIsMobile()
+    const [stopGroups, setStopGroups] = useState<StopGroupWithStops[]>([])
+    const [unassignedStops, setUnassignedStops] = useState<Stop[]>([])
+    const [activeItem, setActiveItem] = useState<null | (StopInstance & { type: "stop" }) | (StopGroupWithStops & { type: "group" })>(null)
+    const [showPrivateGroups, setShowPrivateGroups] = useState(false)
+
+    const sensors = useSensors(
+        useSensor(PointerSensor),
+        useSensor(KeyboardSensor, {
+            coordinateGetter: sortableKeyboardCoordinates,
+        })
+    )
+
+    // helper to locate container for a stop
+    const findContainer = (uid: string): number | "unassigned" | undefined => {
+        if (uid.startsWith("un-")) return "unassigned"
+        const group = stopGroups.find((g) => g.stops.some((s) => s.uid === uid))
+        return group ? group.id : undefined
+    }
+
+    const getStopInstance = (uid: string): StopInstance | undefined => {
+        for (const g of stopGroups) {
+            const item = g.stops.find((s) => s.uid === uid)
+            if (item) return item
+        }
+        return undefined
+    }
+
+    const getStopById = (id: number): Stop | undefined => {
+        return unassignedStops.find((s) => s.id === id)
+    }
+
+    useEffect(() => {
+        // simulate API call
+        const timeout = setTimeout(() => {
+            const fetchedStops: Stop[] = [
+                { id: 1, name: "Welcome", roomNr: "A1", description: "Welcome desk", divisionIds: [], stopGroupIds: [1], orders: [] },
+                { id: 2, name: "Library", roomNr: "B1", description: "Library tour", divisionIds: [], stopGroupIds: [1], orders: [] },
+                { id: 3, name: "Workshop", roomNr: "C1", description: "Hands on", divisionIds: [], stopGroupIds: [], orders: [] },
+                { id: 4, name: "Cafeteria", roomNr: "D1", description: "Snacks", divisionIds: [], stopGroupIds: [], orders: [] },
+            ]
+
+            const fetchedGroups: StopGroup[] = [
+                { id: 1, name: "Information", description: "General information", isPublic: true, stopIds: [1, 2] },
+                { id: 2, name: "Tours", description: "Guided tours", isPublic: false, stopIds: [] },
+            ]
+
+            const groupsWithStops: StopGroupWithStops[] = fetchedGroups.map((g) => ({
+                ...g,
+                stops: fetchedStops
+                    .filter((s) => g.stopIds.includes(s.id))
+                    .map((s) => ({ ...s, uid: crypto.randomUUID() })),
+                isExpanded: true,
+            }))
+
+            const assignedIds = new Set(fetchedGroups.flatMap((g) => g.stopIds))
+            const unassigned = fetchedStops.filter((s) => !assignedIds.has(s.id))
+
+            setStopGroups(groupsWithStops)
+            setUnassignedStops(unassigned)
+        }, 500)
+
+        return () => clearTimeout(timeout)
+    }, [])
+
+    const handleDragStart = (event: DragStartEvent) => {
+        const data = event.active.data.current
+        if (!data) return
+        if (data.type === "group") {
+            setActiveItem({ ...(data.group as StopGroupWithStops), type: "group" })
+        }
+        if (data.type === "stop") {
+            setActiveItem({ ...(data.stop as StopInstance), type: "stop" })
+        }
+    }
+
+    const handleDragEnd = (event: DragEndEvent) => {
+        const { active, over } = event
+        setActiveItem(null)
+        if (!over) return
+
+        const activeData = active.data.current
+        const overData = over.data.current
+        if (!activeData) return
+
+        // reorder groups
+        if (activeData.type === "group" && overData?.type === "group") {
+            const oldIndex = stopGroups.findIndex((g) => g.id === active.id)
+            const newIndex = stopGroups.findIndex((g) => g.id === over.id)
+            if (oldIndex !== -1 && newIndex !== -1 && oldIndex !== newIndex) {
+                setStopGroups(arrayMove(stopGroups, oldIndex, newIndex))
+            }
+            return
+        }
+
+        // moving stops
+        if (activeData.type === "stop") {
+            const uid = String(active.id)
+            const source = findContainer(uid)
+            if (!source) return
+
+            let destination: number | "unassigned" | undefined
+            if (overData?.type === "group") {
+                destination = over.id === "unassigned" ? "unassigned" : Number(over.id)
+            } else if (overData?.type === "stop") {
+                destination = findContainer(String(over.id))
+            } else {
+                return
+            }
+
+            if (!destination) return
+
+            if (destination === source) {
+                if (source === "unassigned") {
+                    const oldIndex = unassignedStops.findIndex((s) => `un-${s.id}` === uid)
+                    const newIndex = unassignedStops.findIndex((s) => `un-${s.id}` === String(over.id))
+                    if (oldIndex !== -1 && newIndex !== -1 && oldIndex !== newIndex) {
+                        setUnassignedStops(arrayMove(unassignedStops, oldIndex, newIndex))
+                    }
+                } else {
+                    const groupIndex = stopGroups.findIndex((g) => g.id === source)
+                    if (groupIndex !== -1) {
+                        const stops = stopGroups[groupIndex].stops
+                        const oldIndex = stops.findIndex((s) => s.uid === uid)
+                        const newIndex = stops.findIndex((s) => s.uid === String(over.id))
+                        if (oldIndex !== -1 && newIndex !== -1 && oldIndex !== newIndex) {
+                            const newStops = arrayMove(stops, oldIndex, newIndex)
+                            setStopGroups((prev) => prev.map((g, idx) => (idx === groupIndex ? { ...g, stops: newStops } : g)))
+                        }
+                    }
+                }
+            } else {
+                if (destination === "unassigned") {
+                    // remove from group
+                    const groupIndex = stopGroups.findIndex((g) => g.id === source)
+                    if (groupIndex !== -1) {
+                        setStopGroups((prev) =>
+                            prev.map((g, idx) =>
+                                idx === groupIndex ? { ...g, stops: g.stops.filter((s) => s.uid !== uid) } : g
+                            )
+                        )
+                    }
+                } else {
+                    // add copy to destination group
+                    const original = uid.startsWith("un-") ? getStopById(Number(uid.slice(3))) : getStopInstance(uid)
+                    if (!original) return
+                    const baseStop: Stop = 'uid' in original ? { ...original } as Stop : original
+                    const newItem: StopInstance = { ...baseStop, uid: crypto.randomUUID() }
+                    setStopGroups((prev) =>
+                        prev.map((g) => (g.id === destination ? { ...g, stops: [...g.stops, newItem] } : g))
+                    )
+                }
+            }
+        }
+    }
+
+    const collapseAll = () => {
+        setStopGroups((prev) => prev.map((g) => ({ ...g, isExpanded: false })))
+    }
+
+    return (
+        <div className="container mx-auto mt-8 space-y-4 pb-8">
+            <StopGroupHeader
+                onCollapseAll={collapseAll}
+                showPrivateGroups={showPrivateGroups}
+                onTogglePrivateGroups={(checked) => setShowPrivateGroups(!!checked)}
+            />
+
+            <DndContext sensors={sensors} collisionDetection={closestCenter} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                    <div className="md:col-span-2 space-y-3">
+                        <SortableContext items={stopGroups.map((g) => g.id)} strategy={verticalListSortingStrategy}>
+                            {stopGroups
+                                .filter((g) => showPrivateGroups || g.isPublic)
+                                .map((group) => (
+                                    <CollapsibleSection
+                                        key={group.id}
+                                        group={group}
+                                        onToggleExpansion={(id) =>
+                                            setStopGroups((prev) =>
+                                                prev.map((g) => (g.id === id ? { ...g, isExpanded: !g.isExpanded } : g))
+                                            )
+                                        }
+                                        onRemoveStop={(uid) =>
+                                            setStopGroups((prev) =>
+                                                prev.map((g) => ({ ...g, stops: g.stops.filter((s) => s.uid !== uid) }))
+                                            )
+                                        }
+                                        isMobile={isMobile}
+                                    />
+                                ))}
+                        </SortableContext>
+                    </div>
+                    <div>
+                        <UnassignedStops stops={unassignedStops} isMobile={isMobile} />
+                    </div>
+                </div>
+
+                <DragOverlay>{activeItem ? <DragItem item={activeItem} /> : null}</DragOverlay>
+            </DndContext>
+        </div>
+    )
+}
+

--- a/src/components/ui/collapsible-section.tsx
+++ b/src/components/ui/collapsible-section.tsx
@@ -5,15 +5,20 @@ import { CSS } from "@dnd-kit/utilities"
 import { ChevronDown, ChevronUp, GripVertical, Info, Layers } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader } from "@/components/ui/card"
-import type { StopGroup } from "@/types/types.ts"
+import type { StopGroup, Stop } from "@/types/types.ts"
 import { SortableStopList } from "./sortable-stop-list"
 import { useDroppable } from "@dnd-kit/core"
 import {useEffect} from "react";
 
+interface StopGroupWithStops extends StopGroup {
+    stops: (Stop & { uid: string })[]
+    isExpanded: boolean
+}
+
 interface CollapsibleSectionProps {
-    group: StopGroup
+    group: StopGroupWithStops
     onToggleExpansion: (groupId: number) => void
-    onRemoveStop: (stopId: string) => void
+    onRemoveStop: (stopUid: string) => void
     isMobile?: boolean
 }
 
@@ -66,7 +71,7 @@ export function CollapsibleSection({
         <Card
             ref={setNodeRef}
             style={style}
-            className="bg-gradient-to-br from-accent-50 to-accent-100/50 border-accent-200 shadow-sm hover:shadow-md transition-all duration-200 drop-zone animate-fade-in"
+            className="bg-card border-border shadow-sm hover:shadow-md transition-all duration-200 drop-zone animate-fade-in"
         >
             <CardHeader className="pb-3">
                 <div className={`flex items-start gap-4 ${isMobile ? "flex-col" : "justify-between"}`}>
@@ -102,12 +107,12 @@ export function CollapsibleSection({
 
             {group.isExpanded && (
                 <CardContent className="pt-0 animate-slide-up">
-                    <div className="bg-white rounded-lg p-4 border border-accent-200/50 shadow-inner">
+                    <div className="bg-muted/50 rounded-lg p-4 border border-border shadow-inner">
                         <h4 className="text-base font-medium text-surface-900 mb-4 flex items-center">
                             <Layers className="w-4 h-4 mr-2 text-accent-600" />
                             Stops
                         </h4>
-                        <SortableStopList stops={} groupId={group.id} onRemoveStop={onRemoveStop} isMobile={isMobile} />
+                        <SortableStopList stops={group.stops} onRemoveStop={onRemoveStop} isMobile={isMobile} />
                     </div>
                 </CardContent>
             )}

--- a/src/components/ui/drag-item.tsx
+++ b/src/components/ui/drag-item.tsx
@@ -1,24 +1,22 @@
 "use client"
 
-import type { StopItem, StopGroup } from "@/app/page"
+import type { Stop, StopGroup } from "@/types/types.ts"
 import { Card, CardContent } from "@/components/ui/card"
 import { Package, Layers } from "lucide-react"
 
 interface DragItemProps {
-    item: StopItem | StopGroup
-    isDragging?: boolean
-    isMobile?: boolean
+    item: (Stop & { type: "stop" }) | (StopGroup & { type: "group" })
 }
 
-export function DragItem({ item, isDragging = false, isMobile = false }: DragItemProps) {
+export function DragItem({ item }: DragItemProps) {
     if (item.type === "group") {
         return (
-            <Card className="bg-gradient-to-br from-accent-100 to-accent-200 border-accent-300 shadow-2xl drag-overlay max-w-md">
+            <Card className="bg-card border border-border shadow-2xl drag-overlay max-w-md">
                 <CardContent className="p-4">
                     <div className="flex items-start gap-3">
                         <Layers className="w-5 h-5 text-accent-700 mt-0.5" />
                         <div>
-                            <h3 className="font-semibold text-surface-900 text-sm">{item.title}</h3>
+                            <h3 className="font-semibold text-surface-900 text-sm">{item.name}</h3>
                             <p className="text-xs text-surface-600 mt-1 line-clamp-2">{item.description}</p>
                         </div>
                     </div>
@@ -28,10 +26,10 @@ export function DragItem({ item, isDragging = false, isMobile = false }: DragIte
     }
 
     return (
-        <div className="bg-white border border-surface-300 rounded-lg p-3 shadow-2xl drag-overlay max-w-xs">
+        <div className="bg-card border border-border rounded-lg p-3 shadow-2xl drag-overlay max-w-xs">
             <div className="flex items-center gap-2">
                 <Package className="w-4 h-4 text-brand-600" />
-                <span className="text-sm font-medium text-surface-900 truncate">{item.title}</span>
+                <span className="text-sm font-medium text-surface-900 truncate">{item.name}</span>
             </div>
         </div>
     )

--- a/src/components/ui/sortable-stop-item.tsx
+++ b/src/components/ui/sortable-stop-item.tsx
@@ -7,14 +7,14 @@ import {Button} from "@/components/ui/button"
 import type {Stop} from "@/types/types.ts";
 
 interface SortableStopItemProps {
-    stop: Stop
+    stop: Stop & { uid: string }
     onRemove: () => void
     isMobile?: boolean
 }
 
 export function SortableStopItem({ stop, onRemove, isMobile = false }: SortableStopItemProps) {
     const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
-        id: stop.id,
+        id: stop.uid,
         data: {
             type: "stop",
             stop,
@@ -31,7 +31,7 @@ export function SortableStopItem({ stop, onRemove, isMobile = false }: SortableS
         <div
             ref={setNodeRef}
             style={style}
-            className="flex items-center justify-between p-3 bg-surface-50 rounded-lg border border-surface-200 hover:bg-surface-100 hover:border-surface-300 transition-all duration-200 group animate-fade-in"
+            className="flex items-center justify-between p-3 bg-muted/20 rounded-lg border border-border hover:bg-muted/40 transition-all duration-200 group animate-fade-in"
         >
             <div className="flex items-center gap-3 flex-1 min-w-0">
                 <button

--- a/src/components/ui/sortable-stop-list.tsx
+++ b/src/components/ui/sortable-stop-list.tsx
@@ -6,16 +6,15 @@ import type { Stop } from "@/types/types.ts"
 import { SortableStopItem } from "./sortable-stop-item"
 
 interface SortableStopListProps {
-    stops: Stop[]
-    groupId: string
-    onRemoveStop: (stopId: number) => void
+    stops: (Stop & { uid: string })[]
+    onRemoveStop: (stopUid: string) => void
     isMobile?: boolean
 }
 
-export function SortableStopList({ stops, groupId, onRemoveStop, isMobile = false }: SortableStopListProps) {
+export function SortableStopList({ stops, onRemoveStop, isMobile = false }: SortableStopListProps) {
     if (stops.length === 0) {
         return (
-            <div className="text-center py-8 text-surface-500 border-2 border-dashed border-surface-200 rounded-lg bg-surface-50/50 drop-zone">
+            <div className="text-center py-8 text-surface-500 border-2 border-dashed border-border rounded-lg bg-muted/10 drop-zone">
                 <Package className="w-8 h-8 mx-auto mb-2 text-surface-400" />
                 <p className="text-sm font-medium">Drop stops here</p>
                 <p className="text-xs text-surface-400 mt-1">Add items to this group</p>
@@ -24,10 +23,10 @@ export function SortableStopList({ stops, groupId, onRemoveStop, isMobile = fals
     }
 
     return (
-        <SortableContext items={stops.map((stop) => stop.id)} strategy={verticalListSortingStrategy}>
+        <SortableContext items={stops.map((stop) => stop.uid)} strategy={verticalListSortingStrategy}>
             <div className="space-y-3 custom-scrollbar max-h-96 overflow-y-auto">
                 {stops.map((stop) => (
-                    <SortableStopItem key={stop.id} stop={stop} onRemove={() => onRemoveStop(stop.id)} isMobile={isMobile} />
+                    <SortableStopItem key={stop.uid} stop={stop} onRemove={() => onRemoveStop(stop.uid)} isMobile={isMobile} />
                 ))}
             </div>
         </SortableContext>

--- a/src/components/ui/unassigned-stop-item.tsx
+++ b/src/components/ui/unassigned-stop-item.tsx
@@ -4,16 +4,16 @@ import { useSortable } from "@dnd-kit/sortable"
 import { CSS } from "@dnd-kit/utilities"
 import { GripVertical, Info } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import type { StopItem } from "@/app/page"
+import type { Stop } from "@/types/types.ts"
 
 interface UnassignedStopItemProps {
-    stop: StopItem
+    stop: Stop
     isMobile?: boolean
 }
 
 export function UnassignedStopItem({ stop, isMobile = false }: UnassignedStopItemProps) {
     const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
-        id: stop.id,
+        id: `un-${stop.id}`,
         data: {
             type: "stop",
             stop,
@@ -30,13 +30,13 @@ export function UnassignedStopItem({ stop, isMobile = false }: UnassignedStopIte
         <div
             ref={setNodeRef}
     style={style}
-    className={`flex items-center justify-between p-3 bg-surface-50 rounded-lg border border-surface-200 hover:bg-surface-100 hover:border-surface-300 transition-all duration-200 group animate-fade-in ${isMobile ? "mobile-drag-handle" : "drag-handle"}`}
+    className={`flex items-center justify-between p-3 bg-muted/20 rounded-lg border border-border hover:bg-muted/40 transition-all duration-200 group animate-fade-in ${isMobile ? "mobile-drag-handle" : "drag-handle"}`}
     {...attributes}
     {...listeners}
 >
     <div className="flex items-center gap-3 flex-1 min-w-0">
     <GripVertical className="h-4 w-4 text-surface-400 group-hover:text-surface-500 transition-colors" />
-    <span className="text-sm font-medium text-surface-900 truncate">{stop.title}</span>
+    <span className="text-sm font-medium text-surface-900 truncate">{stop.name}</span>
         </div>
         <Button size="sm" className="bg-accent-600 hover:bg-accent-700 text-white shadow-sm">
     <Info className="w-3 h-3 mr-1" />

--- a/src/components/ui/unassigned-stops.tsx
+++ b/src/components/ui/unassigned-stops.tsx
@@ -1,18 +1,24 @@
 "use client"
 
 import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable"
+import { useDroppable } from "@dnd-kit/core"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Filter, Package } from "lucide-react"
-import type { StopItem } from "@/app/page"
+import type { Stop } from "@/types/types.ts"
 import { UnassignedStopItem } from "./unassigned-stop-item"
 
 interface UnassignedStopsProps {
-    stops: StopItem[]
+    stops: Stop[]
     isMobile?: boolean
 }
 
 export function UnassignedStops({ stops, isMobile = false }: UnassignedStopsProps) {
+    const { setNodeRef } = useDroppable({
+        id: "unassigned",
+        data: { type: "group", accepts: ["stop"] },
+    })
+
     return (
         <Card className="bg-card border-border shadow-sm hover:shadow-md transition-all duration-200 animate-fade-in">
             <CardHeader className="pb-3">
@@ -28,8 +34,8 @@ export function UnassignedStops({ stops, isMobile = false }: UnassignedStopsProp
                 </div>
             </CardHeader>
             <CardContent className="pt-0">
-                <SortableContext items={stops.map((stop) => stop.id)} strategy={verticalListSortingStrategy}>
-                    <div className="space-y-3 custom-scrollbar max-h-96 overflow-y-auto">
+                <SortableContext items={stops.map((stop) => `un-${stop.id}`)} strategy={verticalListSortingStrategy}>
+                    <div ref={setNodeRef} className="space-y-3 custom-scrollbar max-h-96 overflow-y-auto">
                         {stops.length === 0 ? (
                             <div className="text-center py-8 text-surface-500">
                                 <Package className="w-8 h-8 mx-auto mb-2 text-surface-400" />
@@ -37,7 +43,7 @@ export function UnassignedStops({ stops, isMobile = false }: UnassignedStopsProp
                                 <p className="text-xs text-surface-400 mt-1">All items have been organized</p>
                             </div>
                         ) : (
-                            stops.map((stop) => <UnassignedStopItem key={stop.id} stop={stop} isMobile={isMobile} />)
+                            stops.map((stop) => <UnassignedStopItem key={`un-${stop.id}`} stop={stop} isMobile={isMobile} />)
                         )}
                     </div>
                 </SortableContext>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary
- implement StopGroups page with drag-and-drop using dnd-kit
- connect UI components to Stop and StopGroup types
- allow dropping stops onto unassigned list
- include vite env type declarations
- **allow duplicate stop assignments and improve theme styling**

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6852a60cd4f08328baa4604e60507c51